### PR TITLE
Add .phan/config

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command line arguments will be applied
+ * after this file is read.
+ */
+return [
+
+    // A list of directories that should be parsed for class and
+    // method information. After excluding the directories
+    // defined in exclude_analysis_directory_list, the remaining
+    // files will be statically analyzed for errors.
+    //
+    // Thus, both first-party and third-party code being used by
+    // your application should be included in this list.
+    'directory_list' => [
+        'src',
+        'vendor/aws/aws-sdk-php/src/',
+        'vendor/fguillot/picofeed/lib/PicoFeed/',
+        'vendor/minishlink/web-push/src/',
+        'vendor/pear-pear.php.net/Mail/',
+        'vendor/pimple/pimple/src/',
+        'vendor/predis/predis/src/',
+        'vendor/psr/log/Psr/Log/',
+        'vendor/ramsey/uuid/src/',
+        'vendor/silex/silex/src/',
+        'vendor/symfony/http-foundation/',
+    ],
+
+    // A directory list that defines files that will be excluded
+    // from static analysis, but whose class and method
+    // information should be included.
+    //
+    // Generally, you'll want to include the directories for
+    // third-party code (such as "vendor/") in this list.
+    //
+    // n.b.: If you'd like to parse but not analyze 3rd
+    //       party code, directories containing that code
+    //       should be added to both the `directory_list`
+    //       and `exclude_analysis_directory_list` arrays.
+    "exclude_analysis_directory_list" => [
+        'vendor/'
+    ],
+];


### PR DESCRIPTION
[Phan](https://github.com/etsy/phan) is a static analyzer for PHP.  This tool can also used be in [Code Climate](https://docs.codeclimate.com/docs/phan).

Issue #4 is assisted by Phan.

